### PR TITLE
Update to work with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flex-material",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Flex component built for React based on Angular Material Flex Layout",
   "files": [
     "modules",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/northerneyes/react-flex-material#readme",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.15.0 || ^16.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "angular": "^1.5.8",
     "angular-animate": "^1.5.8",
     "angular-aria": "^1.5.8",
-    "angular-material": "^1.1.1"
+    "angular-material": "^1.1.1",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/Flex.react.js
+++ b/src/Flex.react.js
@@ -1,6 +1,6 @@
 import styles from './Flex.scss';
 
-import React from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 const responsiveModifiers = ['', 'Xs', 'GtXs', 'Sm', 'GtSm', 'Md', 'GtMd', 'Lg', 'GtLg'];
@@ -112,7 +112,7 @@ const attributesToClasses = (attributes, props, prefix = '') => {
 const allFlexAttributes = objectValuesToArray(responsiveAttributes)
   .concat(otherFlexAttributes, ['divider', 'wrap', 'tag']);
 
-export default class Flex extends React.Component {
+export default class Flex extends Component {
   // TODO generate propTypes for attributes
 
   static propTypes = {

--- a/src/Flex.react.js
+++ b/src/Flex.react.js
@@ -1,6 +1,7 @@
 import styles from './Flex.scss';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const responsiveModifiers = ['', 'Xs', 'GtXs', 'Sm', 'GtSm', 'Md', 'GtMd', 'Lg', 'GtLg'];
 
@@ -115,12 +116,12 @@ export default class Flex extends React.Component {
   // TODO generate propTypes for attributes
 
   static propTypes = {
-    divider: React.PropTypes.bool,
-    wrap: React.PropTypes.bool,
+    divider: PropTypes.bool,
+    wrap: PropTypes.bool,
     /** Custom class name */
-    className: React.PropTypes.string,
-    tag: React.PropTypes.node,
-    children: React.PropTypes.node
+    className: PropTypes.string,
+    tag: PropTypes.node,
+    children: PropTypes.node
   };
 
   render() {

--- a/src/Grid.react.js
+++ b/src/Grid.react.js
@@ -1,8 +1,10 @@
 import styles from './Grid.scss';
 
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
-export default class Grid extends React.Component {
+
+export default class Grid extends Component {
   static propTypes = {
     /** Custom class name */
     className: React.PropTypes.string,

--- a/src/Grid.react.js
+++ b/src/Grid.react.js
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types';
 export default class Grid extends Component {
   static propTypes = {
     /** Custom class name */
-    className: React.PropTypes.string,
-    style: React.PropTypes.object,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node),
-      React.PropTypes.node
+    className: PropTypes.string,
+    style: PropTypes.object,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
     ])
   };
 


### PR DESCRIPTION
The current build breaks with react 16, because of:

[https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes)